### PR TITLE
Test if `eif` file exists

### DIFF
--- a/http-proxy/server/build.sh
+++ b/http-proxy/server/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-rm nitro-enclave-python-demo.eif
+FILE=nitro-enclave-python-demo.eif
+if [ -f "$FILE" ]; then
+    rm $FILE
+fi
 docker rmi -f $(docker images -a -q)
 nitro-cli build-enclave --docker-dir ./ --docker-uri richardfan1126/nitro-enclave-python-demo:latest --output-file nitro-enclave-python-demo.eif
 nitro-cli run-enclave --cpu-count 2 --memory 2048 --eif-path nitro-enclave-python-demo.eif --debug-mode


### PR DESCRIPTION
Before removing the output from the last building,  the script should check if the file exists, or it may report an error in cold-starting.